### PR TITLE
Website workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v1
+
+      - name: Install Emacs
+        uses: purcell/setup-emacs@master
+        with:
+          version: 29.3
+
+      - name: Build the site
+        run: |
+          echo "Building the website"
+          pwd
+          emacs -q --script ./publish.el
+
+      - name: Publish generated content to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: public

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.packages
+public

--- a/README.org
+++ b/README.org
@@ -18,21 +18,6 @@ The Lisps we will be exploring:
   - ClojureScript
   - Fennel
 
-Here's a simple diagram showing the family tree of these lisps and how do they relate to each other
-#+begin_src mermaid
-flowchart TD
-    A(Lisp) --> B(Common Lisp)
-    A --> S(Scheme)
-    A --> J(Clojure)
-    S --> E(Chez)
-    E --> R(Racket)
-    S --> I(Chicken)
-    S --> G(Gambit)
-    G --> L(Gerbil)
-    S --> Y(Guile)
-
-#+end_src
-
 * Why Lisps
 ** Syntax
 Lisp has a simple syntax that can be learned in a day. All code is written as expressions, known as S-Expressions, which are lists with prefix notation. The first element is the operator, and the rest are arguments.

--- a/publish.el
+++ b/publish.el
@@ -26,11 +26,12 @@
       org-html-head "<link rel=\"stylesheet\" href=\"https://cdn.simplecss.org/simple.min.css\" />")
 
 (defun rename-project-files (from-regex to)
-  (dolist (from-file (directory-files-recursively "public" from-regex))
+  (dolist (from-file (directory-files-recursively "./public" from-regex))
     (let ((to-file-name (replace-regexp-in-string from-regex to 
 						  from-file t)))
       (message (format "renaming %s to %s" from-file to-file-name))
       (rename-file from-file to-file-name t))))
+
 
 (setq org-publish-project-alist
       (list
@@ -38,7 +39,8 @@
 	"lisp-spectrum"
 	:base-directory "."
 	:base-extension "org"
-	:publishing-directory "public"
+	:publishing-directory "./public"
+	:publishing-function 'org-html-publish-to-html
 	:recursive t
 	:with-toc nil
 	:with-author nil
@@ -48,9 +50,11 @@
 	:time-stamp-file nil
 	:section-numbers nil
 	;; function to be called after publishing the project
-	:completion-function (lambda (proj)
+	:completion-function (lambda (_)
 			       (rename-project-files "README" "index")
 			       (message "Project is now published")))))
 
+(defun publish ()
+  (org-publish-all t))
 
-(org-publish-all t)
+(publish)

--- a/publish.el
+++ b/publish.el
@@ -1,0 +1,56 @@
+;; The Lisp Spectrum project website
+;; To publish the website run the command "emacs -Q -l publish.el"
+;; You can then serve the website from the created public folder
+
+(require 'package)
+
+;; Download packages in a local folder
+(setq package-user-dir (expand-file-name "./.packages"))
+
+(setq package-archives '(("melpa" . "https://melpa.org/packages/")
+                         ("elpa" . "https://elpa.gnu.org/packages/")))
+
+;; Initialize the package system
+(package-initialize)
+(unless package-archive-contents
+  (package-refresh-contents))
+
+;; Install dependencies
+(package-install 'htmlize)
+
+(require 'ox-publish)
+
+;; Customize the HTML output
+(setq org-html-validation-link nil            ;; Don't show validation link
+      org-html-head-include-default-style nil ;; Use our own styles
+      org-html-head "<link rel=\"stylesheet\" href=\"https://cdn.simplecss.org/simple.min.css\" />")
+
+(defun rename-project-files (from-regex to)
+  (dolist (from-file (directory-files-recursively "public" from-regex))
+    (let ((to-file-name (replace-regexp-in-string from-regex to 
+						  from-file t)))
+      (message (format "renaming %s to %s" from-file to-file-name))
+      (rename-file from-file to-file-name t))))
+
+(setq org-publish-project-alist
+      (list
+       (list
+	"lisp-spectrum"
+	:base-directory "."
+	:base-extension "org"
+	:publishing-directory "public"
+	:recursive t
+	:with-toc nil
+	:with-author nil
+	:with-creator nil
+	:with-date nil
+	:with-timestamps nil
+	:time-stamp-file nil
+	:section-numbers nil
+	;; function to be called after publishing the project
+	:completion-function (lambda (proj)
+			       (rename-project-files "README" "index")
+			       (message "Project is now published")))))
+
+
+(org-publish-all t)


### PR DESCRIPTION
This PR creates a `publish.el` script to export the org files to HTML and rename all the `README` files to `index.html`.
It also creates a basic github action to rebuild the website and publish to Github Pages.